### PR TITLE
Better UX flow

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,7 @@ gulp.task('build',['clean', 'qext', 'css'], function () {
 			output:{
 				comments: saveLicense
 			}
-		}))
+		})).on('error', function (err) { gutil.log(gutil.colors.red('[Error]'), err.toString()); })
 		.pipe(gulp.dest(DIST));
 });
 


### PR DESCRIPTION
-No longer start an export when opening the dialog.

-No longer sign-in when loading sheet. Wait until
 it is actually needed.

-Only poll for tasks when we know there is a running
 task.

-If not able to authenticate the user (Firefox mostly)
 try again up to 5 times.

Issue: DEB-46, DEB-49