### PR TITLE
Fixing report download in IE11

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -224,9 +224,19 @@ define(["qlik", "qvangular", "jquery", "core.utils/deferred"],
       });
     },
 
-    downloadTask: function (server, taskId){
-      var df = Deferred();
+    downloadTask: function (server, taskId) {
       var requestUrl = this.doGetActionURL(server, 'api/v1/ondemand/requests/' + taskId + '/result');
+      var df = Deferred();
+
+      if ((navigator.vendor && navigator.vendor.indexOf('Apple') > -1)
+          || /(Trident|MSIE)/.test(navigator.userAgent)) {
+        // Using either an Apple browser or Internet Explorer, which are bad at handling downloads
+        // in an iframe. So just open another tab instead
+        window.open(requestUrl);
+        df.resolve();
+        return df.promise;
+      }
+
       $('#download').on('load', function () {
         df.resolve();
       }).attr('src', requestUrl);


### PR DESCRIPTION
-IE11 has problems handling downloads via iframe
 when using https. Reading about the problem suggests
 there may be a bunch of different things causing this
 problem but all of them relates to how the server is
 configured. So to avoid all that, when using IE,
 download without iframe. This solution opens a new tab
 temporarily, and thus isn't as userfriendly as the iframe
 solution. Therefore, only use it for IE.

Issue: QLIK-93892