### PR TITLE
Show message if sense app id mismatches

### DIFF
--- a/src/template/view-senseid-mismatch-popup.html
+++ b/src/template/view-senseid-mismatch-popup.html
@@ -1,0 +1,16 @@
+<div class="lui-modal-background"></div>
+<div class="lui-dialog qlik-button-for-navigation">
+    <div class="lui-dialog__header">
+        <div class="lui-dialog__title">Sense app mismatch</div>
+    </div>
+    <div class="lui-dialog__body">
+        <label>The On-demand reporting is configured for a different Sense app and won't work with the current configuration. Update the connection on the NPrinting server.</label>
+    </div>
+    <div class="lui-dialog__footer">
+        <button
+            class="lui-button close-button"
+            ng-click="close()"
+            name="closeButton"
+            data-tid="close-btn">Close</button>
+    </div>
+</div>


### PR DESCRIPTION
-Make user aware of the fact on-demand reporting
 won't work with the previous Connection if the
 sense app id has changed.

-Show error if there are no connections for the
 current sense app.

Issue: QLIK-95649